### PR TITLE
Add precommit scripts

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1163,6 +1163,17 @@
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
       "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
     },
+    "concat-stream": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.6.0.tgz",
+      "integrity": "sha1-CqxmL9Ur54lk1VMvaUeE5wEQrPc=",
+      "dev": true,
+      "requires": {
+        "inherits": "2.0.3",
+        "readable-stream": "2.3.3",
+        "typedarray": "0.0.6"
+      }
+    },
     "concurrently": {
       "version": "3.5.0",
       "resolved": "https://registry.npmjs.org/concurrently/-/concurrently-3.5.0.tgz",
@@ -2707,6 +2718,12 @@
         "lcid": "1.0.0"
       }
     },
+    "os-shim": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/os-shim/-/os-shim-0.1.3.tgz",
+      "integrity": "sha1-a2LDeRz3kJ6jXtRuF2WLtBfLORc=",
+      "dev": true
+    },
     "os-tmpdir": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
@@ -2862,6 +2879,17 @@
       "integrity": "sha1-yBmscoBZpGHKscOImivjxJoATX8=",
       "requires": {
         "find-up": "2.1.0"
+      }
+    },
+    "pre-commit": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/pre-commit/-/pre-commit-1.2.2.tgz",
+      "integrity": "sha1-287g7p3nI15X95xW186UZBpp7sY=",
+      "dev": true,
+      "requires": {
+        "cross-spawn": "5.1.0",
+        "spawn-sync": "1.0.15",
+        "which": "1.2.14"
       }
     },
     "preserve": {
@@ -3464,6 +3492,16 @@
       "integrity": "sha1-YvXpRmmBwbeW3Fkpk34RycaSG9A=",
       "dev": true
     },
+    "spawn-sync": {
+      "version": "1.0.15",
+      "resolved": "https://registry.npmjs.org/spawn-sync/-/spawn-sync-1.0.15.tgz",
+      "integrity": "sha1-sAeZVX63+wyDdsKdROih6mfldHY=",
+      "dev": true,
+      "requires": {
+        "concat-stream": "1.6.0",
+        "os-shim": "0.1.3"
+      }
+    },
     "spdx-correct": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-1.0.2.tgz",
@@ -3762,6 +3800,12 @@
       "version": "0.0.0",
       "resolved": "https://registry.npmjs.org/tty-browserify/-/tty-browserify-0.0.0.tgz",
       "integrity": "sha1-oVe6QC2iTpv5V/mqadUk7tQpAaY="
+    },
+    "typedarray": {
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
+      "integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=",
+      "dev": true
     },
     "typescript": {
       "version": "2.4.1",

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "predev": "tsc && cp -R static dist/",
     "dev": "concurrently \"tsc --watch\" \"next dist\"",
     "start": "next start dist",
+    "prettier": "prettier --parser typescript --single-quote --trailing-comma all --write \"./**/*.ts\"",
     "tslint": "tslint -c tslint.json -p tsconfig.json"
   },
   "repository": {

--- a/package.json
+++ b/package.json
@@ -12,6 +12,10 @@
     "prettier": "prettier --parser typescript --single-quote --trailing-comma all --write \"./**/*.ts\"",
     "tslint": "tslint -c tslint.json -p tsconfig.json"
   },
+  "pre-commit": [
+    "prettier",
+    "tslint"
+  ]
   "repository": {
     "type": "git",
     "url": "git+https://github.com/ChrisALee/twitch-stocks.git"
@@ -35,6 +39,7 @@
   },
   "devDependencies": {
     "concurrently": "^3.5.0",
+    "pre-commit": "^1.2.2",
     "prettier": "^1.5.3",
     "tslint": "^5.5.0",
     "tslint-config-prettier": "^1.1.0"

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
   "pre-commit": [
     "prettier",
     "tslint"
-  ]
+  ],
   "repository": {
     "type": "git",
     "url": "git+https://github.com/ChrisALee/twitch-stocks.git"


### PR DESCRIPTION
This PR adds precommit which runs the prettier and tslint scripts before each commit.

This should add some extra consistency enforcement.

Once we have tests, precommit will run those as well.