### PR TITLE
Removed pre-commit scripts

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -16,8 +16,8 @@
     "coveralls": "jest && cat ./coverage/lcov.info | ./node_modules/coveralls/bin/coveralls.js && rm -rf ./coverage",
     "lint-staged": "lint-staged"
   },
-  "pre-commit": "lint-staged",
   "lint-staged": {
+    "gitDir": "../",
     "*.ts*": [
       "tslint -c tslint.json -p tsconfig.json --fix",
       "prettier --parser typescript --single-quote --trailing-comma all --write",

--- a/server/package.json
+++ b/server/package.json
@@ -15,8 +15,8 @@
     "server-dev": "concurrently \"npm run server:build\" \"npm run server:watch\"",
     "server": "npm run server:watch"
   },
-  "pre-commit": "lint-staged",
   "lint-staged": {
+    "gitDir": "../",
     "*.ts*": [
       "tslint -c tslint.json -p tsconfig.json --fix",
       "prettier --parser typescript --single-quote --trailing-comma all --write",

--- a/twitch/package.json
+++ b/twitch/package.json
@@ -14,8 +14,8 @@
     "twitch:watch": "nodemon \"dist/index.js\" --watch \"dist/*\"",
     "twitch": "concurrently \"npm run twitch:build\" \"npm run twitch:watch\""
   },
-  "pre-commit": "lint-staged",
   "lint-staged": {
+    "gitDir": "../",
     "*.ts*": [
       "tslint -c tslint.json -p tsconfig.json --fix",
       "prettier --parser typescript --single-quote --trailing-comma all --write",


### PR DESCRIPTION
npm run lint-staged should be run manually in each services folder for the time being.

Using "gitDir": "../" fixes lint-staged when run manually